### PR TITLE
Accept also lowercase `y`

### DIFF
--- a/parse_to_syncano/moses.py
+++ b/parse_to_syncano/moses.py
@@ -81,7 +81,7 @@ def sync(namespace):
                                  instance_name=instance_name)
                              ) or 'Y'
 
-    if confirmation != 'Y':
+    if confirmation.upper() != 'Y':
         return
 
     transfer = SyncanoTransfer()


### PR DESCRIPTION
I tried passing `y` a couple of times and I thought the tool was broken before I realized it accepts only uppercase
